### PR TITLE
Resolves Issue #103 noqa comments

### DIFF
--- a/flake8_eradicate.py
+++ b/flake8_eradicate.py
@@ -93,7 +93,7 @@ class Checker(object):
         when the tokens indicate a comment in the physical line.
 
         """
-        comment_in_line: bool = False
+        comment_in_line = False
         for token_type, _, _, _, _ in self._tokens:
             if token_type == tokenize.COMMENT:
                 comment_in_line = True

--- a/flake8_eradicate.py
+++ b/flake8_eradicate.py
@@ -75,16 +75,22 @@ class Checker(object):
 
     def __iter__(self) -> Iterable[Tuple[int, str]]:
         """Runs on each step of flake8."""
-        if not self._is_equal_source():
+        if self._contains_commented_out_code():
             yield (1, self._error_template)
 
-    def _is_equal_source(self) -> bool:
+    def _contains_commented_out_code(self) -> bool:
         """
-        Check eradicate removes commented out code from line.
+        Check if the current physical line contains commented out code.
 
-        This check is only necessary when the physical line contains a comment.
-        The existence of comments is tested with the tokens of the physical
-        line.
+        This test relies on eradicate function to remove commented out code
+        from a physical line.
+
+        Physical lines might appear like commented code although they are part
+        of a multi-line docstring (e.g. a `# noqa: DAR201` comment to suppress
+        flake8 warning about missing returns in the docstring).
+        To prevent this false-positive, the tokens of the physical line are
+        checked for a comment. The eradicate function is only invokes,
+        when the tokens indicate a comment in the physical line.
 
         """
         comment_in_line: bool = False
@@ -96,5 +102,5 @@ class Checker(object):
             filtered_source = ''.join(filter_commented_out_code(
                 self._physical_line, self._options,
             ))
-            return self._physical_line == filtered_source
-        return True
+            return self._physical_line != filtered_source
+        return False

--- a/tests/fixtures/correct.py
+++ b/tests/fixtures/correct.py
@@ -34,3 +34,21 @@ class Some(object):
 
         # Some logics: count(numbers) or print(False)
         print(12 + 23 / 3)
+
+
+def some_function():
+    """
+    Test for noqa comments in docstrings.
+
+    This function has a multi-line doc string, but no return value is
+    stipulated, while the function defines a return. This would raise DAR201
+    flake8 violation. To suppress this raise violation the following noqa
+    comment is defined in the docstring.
+
+    # noqa: DAR201
+
+    This noqa comment should not be detected as commented out code. `eradicate`
+    itself does not raise this as a violation.
+
+    """
+    return "something"


### PR DESCRIPTION
Previously, `noqa` comments inside of a multi-line docstring where flagged as commented out code. When using `eradicate` directly on a file which includes such a `noqa` comment it does not show a violation. 

Example of such a multi-line docstring:
```python
def some_function():
    """
    Test for noqa comments in docstrings.

    This function has a multi-line doc string, but no return value is
    stipulated, while the function defines a return. This would raise DAR201
    flake8 violation. To suppress this raise violation the following noqa
    comment is defined in the docstring.

    # noqa: DAR201

    This noqa comment should not be detected as commented out code. `eradicate`
    itself does not raise this as a violation.

    """
    return "something"
```

This kind of `noqa` comments are needed to suppress violations raised by [`darglint`](https://github.com/terrencepreilly/darglint#ignoring-errors-in-a-docstring), e.g. violations associated with missing return statements in the docstring. 

This issue is caused by passing isolated physical lines of code to the `eradicate` function `filter_commented_out_code`. That function does expect to operate on a file's whole source code rather than on isolated lines of code. From the whole source code the context of each line can be determined. This allows differentiation between actual comment lines and lines that only look like comments. 

To resolve this issue, while still keeping the checker on one physical line at a time, a preliminary test is introduced that checks if the current physical line contains a comment according to the tokens of the physical line. These tokens are available as input to the plugin from `flake8`. 

Solves #103 
