### PR TITLE
Fix mypy command in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -46,7 +46,7 @@ We use `mypy` to run type checks on our code.
 To use it:
 
 ```bash
-mypy wemake_python_styleguide
+mypy flake8_eradicate.py
 ```
 
 This step is mandatory during the CI.


### PR DESCRIPTION
The mypy command was previously defined as follows:
```bash
mypy wemake_python_styleguide
```

Running this command resulted in the following error message:
```
mypy: can't read file 'wemake_python_styleguide': No such file or directory
```

The contribution guidelines are probably copied over from
`wemake_python_styleguide` and the mypy command has not been updated
to the new module name.

The mypy command is now updated to
```bash
mypy flake8_eradicate.py
```
This command works and is also the command used in the `.travis.yml`
for running mypy during CI.