### PR TITLE
remove colon from error code

### DIFF
--- a/flake8_eradicate.py
+++ b/flake8_eradicate.py
@@ -31,7 +31,7 @@ class Checker(object):
 
     name = pkg_name
     version = pkg_version
-    _error_template = 'E800: Found commented out code'
+    _error_template = 'E800 Found commented out code'
 
     options = None
 


### PR DESCRIPTION
when doing physical check, flake8 will get error code by `error_code, text = text.split(" ", 1)`.

So flake8 will take `E800:` as error code instead of `E800`

when using customized report format, it will cause some problems.

